### PR TITLE
Add anchor links to headings, fixes freenode/web-7.0#135

### DIFF
--- a/cms7/source.py
+++ b/cms7/source.py
@@ -43,7 +43,7 @@ class MarkdownSource:
                 TableExtension(),
                 WikiLinkExtension(),
                 CMS7Extension(gs, path=self.source, baselevel=baselevel, hyphenate=hyphenate, paragraphs=paragraphs),
-                TocExtension()
+                TocExtension(anchorlink=True)
             ],
             output_format='html5')
         return Markup(md.convert(self.text))


### PR DESCRIPTION
Using the inbuilt anchorLinks option from TocExtension as discussed internally. 

This makes the feature of having linkable anchors a bit more discover- and useable, as users referencing documentation in their projects seems to not have been aware of that.

Should be tested on all kind of pages (not just kb) and maybe css needs some changes to make it look not-ugly and non-distractive.

fixes freenode/web-7.0#135